### PR TITLE
Adds support for formatting reports containing data for multiple date ranges.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
  "criterion 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "indoc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "joinery 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -268,11 +268,6 @@ dependencies = [
 [[package]]
 name = "itoa"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "joinery"
-version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -671,7 +666,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itertools-num 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "83ca7b70b838f2e34bc6c2f367a1ed1cfe34fb82464adecadd31cdcc7da882fc"
 "checksum itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606"
-"checksum joinery 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85dc817f5154c0d9d56c2adfdd862943cfb20a4206d2eaccfb0db0371b9ebf64"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cba860f648db8e6f269df990180c2217f333472b4a6e901e97446858487971e2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 authors = ["Charlie Saunders <charlieasaunders@gmail.com>"]
 
 [dependencies]
+itertools = "0.7.8"
 failure = "0.1.2"
-joinery = "1.0.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 extern crate failure;
-extern crate joinery;
+extern crate itertools;
 extern crate serde;
 
 #[cfg(test)]

--- a/src/to_delimited.rs
+++ b/src/to_delimited.rs
@@ -156,18 +156,42 @@ mod tests {
             vec![
                 indoc!(
                     r#""ga:deviceCategory","ga:sessions","ga:bounces"
-                "desktop",25,17
-                "mobile",2,2
-                "#
+                    "desktop",25,17
+                    "mobile",2,2
+                    "#
                 ).to_string(),
                 indoc!(
                     r#""ga:country","ga:sessions","ga:bounces"
-                "Azerbaijan",1,0
-                "France",18,11
-                "Japan",4,4
-                "Switzerland",1,1
-                "United States",3,3
-                "#
+                    "Azerbaijan",1,0
+                    "France",18,11
+                    "Japan",4,4
+                    "Switzerland",1,1
+                    "United States",3,3
+                    "#
+                ).to_string(),
+            ]
+        )
+    }
+
+    #[test]
+    fn multiple_date_ranges() {
+        let data: String = fs::read_to_string(PathBuf::from(format!(
+            "{}{}",
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_reports/multiple_date_ranges.json"
+        ))).unwrap();
+
+        let deserialized_response: ReportResponse = serde_json::from_str(data.as_str()).unwrap();
+
+        assert_eq!(
+            response_to_delimited_reports(&deserialized_response, ","),
+            vec![
+                indoc!(
+                    r#""ga:browser","ga:avgTimeOnPage","ga:pageviewsPerSession","ga:avgTimeOnPage_2","ga:pageviewsPerSession_2"
+                    "Chrome",108.1733,2.93126,129.7071651,3.60975609
+                    "Edge",51.794117,6.6666667,210.866667,2.875
+                    "Firefox",123.657142,2.09375,75.333333,1.5
+                    "#
                 ).to_string(),
             ]
         )

--- a/src/to_delimited.rs
+++ b/src/to_delimited.rs
@@ -1,4 +1,4 @@
-use joinery::Joinable;
+use itertools::Itertools;
 use types::*;
 
 pub fn response_to_delimited_reports(response: &ReportResponse, delimiter: &str) -> Vec<String> {
@@ -26,7 +26,7 @@ fn report_to_flat(report: &Report, delimiter: &str) -> String {
         "{}\n",
         dimension_header_iter
             .chain(metric_header_iter)
-            .join_with(delimiter)
+            .join(delimiter)
             .to_string()
     );
 
@@ -37,19 +37,14 @@ fn report_to_flat(report: &Report, delimiter: &str) -> String {
                     .dimensions
                     .iter()
                     .map(|entry| format!("\"{}\"", entry))
-                    .join_with(delimiter)
+                    .join(delimiter)
                     .to_string()
                     .as_str(),
             );
             result.push_str(delimiter);
         };
 
-        let metric_data = report_row
-            .metrics
-            .iter()
-            .flat_map(|date_range_value| date_range_value.values.iter())
-            .join_with(delimiter)
-            .to_string();
+        let metric_data = report_row.flat_value_iterator().join(delimiter).to_string();
 
         result.push_str(format!("{}\n", metric_data).as_str());
     });

--- a/src/to_delimited.rs
+++ b/src/to_delimited.rs
@@ -16,9 +16,11 @@ fn report_to_flat(report: &Report, delimiter: &str) -> String {
         .iter()
         .map(|entry| format!("\"{}\"", entry));
 
-    let metric_header_iter = report
-        .get_metric_header_iterator()
-        .map(|entry: &MetricHeaderEntry| format!("\"{}\"", &entry.name));
+    let metric_headers = report.get_metric_headers();
+
+    let metric_header_iter = metric_headers
+        .iter()
+        .map(|entry: &MetricHeaderEntry| format!("\"{}\"", entry.name));
 
     let mut result = format!(
         "{}\n",

--- a/src/to_row_array.rs
+++ b/src/to_row_array.rs
@@ -196,4 +196,40 @@ mod tests {
             ])
         )
     }
+
+    #[test]
+    fn multiple_date_ranges() {
+        let data: String = fs::read_to_string(PathBuf::from(format!(
+            "{}{}",
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_reports/multiple_date_ranges.json"
+        ))).unwrap();
+
+        let parsed_response: ReportResponse = serde_json::from_str(data.as_str()).unwrap();
+
+        assert_eq!(
+            response_to_row_array(&parsed_response),
+            json!([
+                [{
+                    "ga:browser": "Chrome",
+                    "ga:avgTimeOnPage": 108.1733,
+                    "ga:pageviewsPerSession": 2.93126,
+                    "ga:avgTimeOnPage2": 129.7071651,
+                    "ga:pageviewsPerSession2": 3.60975609,
+                }, {
+                    "ga:browser": "Edge",
+                    "ga:avgTimeOnPage": 51.794117,
+                    "ga:pageviewsPerSession": 6.6666667,
+                    "ga:avgTimeOnPage2": 210.866667,
+                    "ga:pageviewsPerSession2": 2.875,
+                }, {
+                    "ga:browser": "Firefox",
+                    "ga:avgTimeOnPage": 123.657142,
+                    "ga:pageviewsPerSession": 2.09375,
+                    "ga:avgTimeOnPage2": 75.333333,
+                    "ga:pageviewsPerSession2": 1.5,
+                }]
+            ])
+        )
+    }
 }

--- a/src/to_row_array.rs
+++ b/src/to_row_array.rs
@@ -53,10 +53,7 @@ fn insert_metric_data(
     row: &ReportRow,
     metric_header_iter: &Iter<MetricHeaderEntry>,
 ) {
-    let value_iterator = row
-        .metrics
-        .iter()
-        .flat_map(|value: &DateRangeValue| value.values.iter());
+    let value_iterator = row.flat_value_iterator();
 
     for (header, value) in metric_header_iter.clone().zip(value_iterator) {
         current.insert(

--- a/src/types.rs
+++ b/src/types.rs
@@ -100,6 +100,14 @@ pub struct ReportRow {
     pub metrics: Vec<DateRangeValue>,
 }
 
+impl ReportRow {
+    pub fn flat_value_iterator<'a>(&'a self) -> impl Iterator<Item = &String> {
+        self.metrics
+            .iter()
+            .flat_map(|value: &'a DateRangeValue| value.values.iter())
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DateRangeValue {
     pub values: Vec<String>,

--- a/test_reports/multiple_date_ranges.json
+++ b/test_reports/multiple_date_ranges.json
@@ -1,0 +1,128 @@
+{
+  "reports": [
+    {
+      "columnHeader": {
+        "dimensions": [
+          "ga:browser"
+        ],
+        "metricHeader": {
+          "metricHeaderEntries": [
+            {
+              "name": "ga:avgTimeOnPage",
+              "type": "TIME"
+            },
+            {
+              "name": "ga:pageviewsPerSession",
+              "type": "FLOAT"
+            }
+          ]
+        }
+      },
+      "data": {
+        "rows": [
+          {
+            "dimensions": [
+              "Chrome"
+            ],
+            "metrics": [
+              {
+                "values": [
+                  "108.1733",
+                  "2.93126"
+                ]
+              },
+              {
+                "values": [
+                  "129.7071651",
+                  "3.60975609"
+                ]
+              }
+            ]
+          },
+          {
+            "dimensions": [
+              "Edge"
+            ],
+            "metrics": [
+              {
+                "values": [
+                  "51.794117",
+                  "6.6666667"
+                ]
+              },
+              {
+                "values": [
+                  "210.866667",
+                  "2.875"
+                ]
+              }
+            ]
+          },
+          {
+            "dimensions": [
+              "Firefox"
+            ],
+            "metrics": [
+              {
+                "values": [
+                  "123.657142",
+                  "2.09375"
+                ]
+              },
+              {
+                "values": [
+                  "75.333333",
+                  "1.5"
+                ]
+              }
+            ]
+          }
+        ],
+        "totals": [
+          {
+            "values": [
+              "89.31735436893204",
+              "3.4342688330871494"
+            ]
+          },
+          {
+            "values": [
+              "155.70253164556962",
+              "3.0343347639484977"
+            ]
+          }
+        ],
+        "rowCount": 3,
+        "minimums": [
+          {
+            "values": [
+              "0.0",
+              "0.0"
+            ]
+          },
+          {
+            "values": [
+              "0.0",
+              "0.0"
+            ]
+          }
+        ],
+        "maximums": [
+          {
+            "values": [
+              "364.8",
+              "6.666666666666667"
+            ]
+          },
+          {
+            "values": [
+              "267.4",
+              "5.4"
+            ]
+          }
+        ],
+        "isDataGolden": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #5 

Ended up switching from [Joinery](https://github.com/Lucretiel/joinery) to [Itertools](https://github.com/bluss/rust-itertools). Itertools was able to handle joining the result of `flat_value_iterator`, which is a `FlatMap`.