### PR TITLE
Fixes issue where the flat JSON returned for empty reports was a string of '[]' instead of an empty array.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ga-v4-flattener"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ga-v4-flattener"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Charlie Saunders <charlieasaunders@gmail.com>"]
 description = "Converts Google Analytics API v4 reports to flat/delimited data."
 repository = "https://github.com/C-Saunders/google_analytics_v4_report_flattener"

--- a/src/to_delimited.rs
+++ b/src/to_delimited.rs
@@ -61,6 +61,22 @@ mod tests {
     use types::ReportResponse;
 
     #[test]
+    fn no_rows() {
+        let data: String = fs::read_to_string(PathBuf::from(format!(
+            "{}{}",
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_reports/no_rows.json"
+        ))).unwrap();
+
+        let deserialized_response: ReportResponse = serde_json::from_str(data.as_str()).unwrap();
+
+        assert_eq!(
+            response_to_delimited_reports(&deserialized_response, ","),
+            vec!["\"ga:deviceCategory\",\"ga:sessions\"\n"]
+        )
+    }
+
+    #[test]
     fn no_dimensions() {
         let data: String = fs::read_to_string(PathBuf::from(format!(
             "{}{}",

--- a/src/to_row_array.rs
+++ b/src/to_row_array.rs
@@ -15,7 +15,7 @@ pub fn response_to_row_array(response: &ReportResponse) -> Value {
 fn report_to_row_array(report: &Report) -> Value {
     let report_rows = &report.data.rows;
     if report_rows.is_empty() {
-        return json!("[]");
+        return json!([]);
     }
 
     let dimension_headers = &report.column_header.dimensions;
@@ -70,6 +70,19 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
     use types::ReportResponse;
+
+    #[test]
+    fn no_rows() {
+        let data: String = fs::read_to_string(PathBuf::from(format!(
+            "{}{}",
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_reports/no_rows.json"
+        ))).unwrap();
+
+        let parsed_response: ReportResponse = serde_json::from_str(data.as_str()).unwrap();
+
+        assert_eq!(response_to_row_array(&parsed_response), json!([[]]))
+    }
 
     #[test]
     fn no_dimensions() {


### PR DESCRIPTION
Also adds tests for reports with no rows of data. That test report file was previously unused.