### PR TITLE
Removes use of Failure crate.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 **/*.rs.bk
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,10 +202,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ga-v4-flattener"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "criterion 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "indoc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ga-v4-flattener"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Charlie Saunders <charlieasaunders@gmail.com>"]
 description = "Converts Google Analytics API v4 reports to flat/delimited data."
 repository = "https://github.com/C-Saunders/google_analytics_v4_report_flattener"
@@ -9,7 +9,6 @@ exclude = ["test_reports/*", "benches/*"]
 
 [dependencies]
 itertools = "0.7.8"
-failure = "0.1.2"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This library exposes two public functions that accept a [Google Analytics Core R
 
 ### Report to delimited (e.g. TSV, CSV)
 
-`to_delimited(raw_report_response: &str, delimiter: &str) -> Result<Vec<String>, failure::Error>`
+`to_delimited(raw_report_response: &str, delimiter: &str) -> Result<Vec<String>, serde_json::Error>`
 
 Converts a report response to a collection of delimited reports. You can specify any delimiter string you'd like.
 
@@ -12,7 +12,7 @@ Converts a report response to a collection of delimited reports. You can specify
 
 ### Report to flat JSON (flat array of row data)
 
-`to_flat_json(raw_report: &str) -> Result<serde_json::value::Value, failure::Error>`
+`to_flat_json(raw_report: &str) -> Result<serde_json::value::Value, serde_json::Error>`
 
 Converts a report response to an array of "flat JSON" responses.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-extern crate failure;
 extern crate itertools;
 extern crate serde;
 
@@ -14,8 +13,8 @@ mod to_delimited;
 mod to_row_array;
 pub mod types;
 
-use failure::Error;
 use serde_json::value::Value;
+use serde_json::Error;
 use to_delimited::response_to_delimited_reports;
 use to_row_array::response_to_row_array;
 use types::ReportResponse;


### PR DESCRIPTION
Since this changes the API (`Result<T, failure::Error>` => `Result<T, serde_json::Error>`) this is also a major version bump.